### PR TITLE
Added unsupportedClasses to Fixture

### DIFF
--- a/scalecube-fixtures-tck-flow/src/main/java/io/scalecube/test/fixtures/BaseTest.java
+++ b/scalecube-fixtures-tck-flow/src/main/java/io/scalecube/test/fixtures/BaseTest.java
@@ -4,10 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestTemplate;
 
 /** Extend this test with your annotations. you may add some more tests. */
 public class BaseTest {
+
+  @BeforeEach
+  void setUp(TestInfo testInfo) {
+    System.out.println(testInfo.getDisplayName() + " started");
+  }
 
   /**
    * basic test.

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
@@ -1,6 +1,12 @@
 package io.scalecube.test.fixtures;
 
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.jupiter.api.RepetitionInfo;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opentest4j.TestAbortedException;
@@ -83,5 +89,9 @@ public interface Fixture {
 
   default String name() {
     return getClass().getSimpleName();
+  }
+
+  default Collection<Class<?>> unsupportedClasses() {
+    return Arrays.asList(RepetitionInfo.class, TestInfo.class, TestReporter.class);
   }
 }

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
@@ -1,12 +1,6 @@
 package io.scalecube.test.fixtures;
 
 import java.lang.reflect.Proxy;
-import java.util.Arrays;
-import java.util.Collection;
-
-import org.junit.jupiter.api.RepetitionInfo;
-import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opentest4j.TestAbortedException;

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
@@ -90,8 +90,4 @@ public interface Fixture {
   default String name() {
     return getClass().getSimpleName();
   }
-
-  default Collection<Class<?>> unsupportedClasses() {
-    return Arrays.asList(RepetitionInfo.class, TestInfo.class, TestReporter.class);
-  }
 }

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
@@ -111,15 +111,10 @@ public class Fixtures
       ParameterContext parameterContext, ExtensionContext extensionContext)
       throws ParameterResolutionException {
     Class<?> type = parameterContext.getParameter().getType();
-        if (type
-        .getPackage()
-        .getName()
-        .startsWith("org.junit.jupiter.api")) {
+    if (type.getPackage().getName().startsWith("org.junit.jupiter.api")) {
       return false;
     }
-    return getStore(extensionContext)
-        .map(getFixtureFromStore)
-        .isPresent();
+    return getStore(extensionContext).map(getFixtureFromStore).isPresent();
   }
 
   @Override

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
@@ -111,10 +111,15 @@ public class Fixtures
       ParameterContext parameterContext, ExtensionContext extensionContext)
       throws ParameterResolutionException {
     Class<?> type = parameterContext.getParameter().getType();
+        if (type
+        .getPackage()
+        .getName()
+        .startsWith("org.junit.jupiter.api")) {
+      return false;
+    }
     return getStore(extensionContext)
         .map(getFixtureFromStore)
-        .map(fixture -> fixture.unsupportedClasses().stream().noneMatch(type::equals))
-        .orElse(false);
+        .isPresent();
   }
 
   @Override

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
@@ -110,7 +110,11 @@ public class Fixtures
   public boolean supportsParameter(
       ParameterContext parameterContext, ExtensionContext extensionContext)
       throws ParameterResolutionException {
-    return getStore(extensionContext).map(getFixtureFromStore).isPresent();
+    Class<?> type = parameterContext.getParameter().getType();
+    return getStore(extensionContext)
+        .map(getFixtureFromStore)
+        .map(fixture -> fixture.unsupportedClasses().stream().noneMatch(type::equals))
+        .orElse(false);
   }
 
   @Override


### PR DESCRIPTION
Motivation: currently I can't ask for `TestInfo` instance as an argument of JUnit methods.
So as an option will be nice to have a method which will specify which classes should be excluded for `proxyFor` method.