### PR TITLE
Teardown fixture if setup failed: fix for #23

### DIFF
--- a/scalecube-docker-fixture/src/main/java/org/testcontainers/utility/DockerfileFixture.java
+++ b/scalecube-docker-fixture/src/main/java/org/testcontainers/utility/DockerfileFixture.java
@@ -4,6 +4,7 @@ import io.scalecube.test.fixtures.EchoService;
 import io.scalecube.test.fixtures.Fixture;
 import io.scalecube.test.fixtures.PalindromeService;
 import java.io.IOException;
+import org.opentest4j.TestAbortedException;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
@@ -17,12 +18,17 @@ public class DockerfileFixture implements Fixture {
   @Override
   public void setUp() {
 
-    ImageFromDockerfile imageFromDockerfile =
-        new ImageFromDockerfile()
-            .withDockerfileFromBuilder(
-                builder -> builder.from("ubuntu").entryPoint("sleep infinity").build());
-    genericContainer = new GenericContainer<>(imageFromDockerfile);
-    genericContainer.start();
+    try {
+      ImageFromDockerfile imageFromDockerfile =
+          new ImageFromDockerfile()
+              .withDockerfileFromBuilder(
+                  builder -> builder.from("ubuntu").entryPoint("sleep infinity").build());
+      genericContainer = new GenericContainer<>(imageFromDockerfile);
+      genericContainer.start();
+    } catch (Exception cause) { 
+      throw new TestAbortedException("unable to start docker", cause);
+    }
+
     echoService =
         s -> {
           try {

--- a/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureConstructor.java
+++ b/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureConstructor.java
@@ -1,0 +1,33 @@
+package io.scalecube.test.fixtures;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.opentest4j.TestAbortedException;
+
+public class FailingFixtureConstructor implements Fixture {
+
+  boolean setupStarted = false;
+
+  public FailingFixtureConstructor() {
+    throw new IllegalArgumentException();
+  }
+
+  @Override
+  public void setUp() throws TestAbortedException {
+    setupStarted = true;
+    throw new TestAbortedException("Fixture Setup Failed");
+  }
+
+  @Override
+  public <T> T proxyFor(Class<? extends T> clasz) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void tearDown() {
+    System.out.println(" terminating " + this.getClass().getSimpleName());
+    assertFalse(setupStarted);
+  }
+}

--- a/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureConstructor.java
+++ b/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureConstructor.java
@@ -1,13 +1,12 @@
 package io.scalecube.test.fixtures;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.opentest4j.TestAbortedException;
 
 public class FailingFixtureConstructor implements Fixture {
 
-  boolean setupStarted = false;
+  private boolean setupStarted = false;
 
   public FailingFixtureConstructor() {
     throw new IllegalArgumentException();

--- a/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureInSetup.java
+++ b/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureInSetup.java
@@ -1,0 +1,28 @@
+package io.scalecube.test.fixtures;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.opentest4j.TestAbortedException;
+
+public class FailingFixtureInSetup implements Fixture {
+
+  boolean setupStarted = false;
+
+  @Override
+  public void setUp() throws TestAbortedException {
+    setupStarted = true;
+    throw new TestAbortedException("Fixture Setup Failed");
+  }
+
+  @Override
+  public <T> T proxyFor(Class<? extends T> clasz) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void tearDown() {
+    System.out.println(" terminating " + this.getClass().getSimpleName());
+    assertTrue(setupStarted);
+  }
+}

--- a/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureInSetup.java
+++ b/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingFixtureInSetup.java
@@ -6,7 +6,7 @@ import org.opentest4j.TestAbortedException;
 
 public class FailingFixtureInSetup implements Fixture {
 
-  boolean setupStarted = false;
+  private boolean setupStarted = false;
 
   @Override
   public void setUp() throws TestAbortedException {

--- a/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingTest.java
+++ b/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingTest.java
@@ -1,0 +1,23 @@
+package io.scalecube.test.fixtures;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+//@WithFixture(value = FailingFixtureConstructor.class)
+@WithFixture(value = FailingFixtureInSetup.class)
+@ExtendWith(Fixtures.class)
+public class FailingTest {
+
+  @BeforeEach
+  void setUp(TestInfo testInfo) {
+    System.out.println(testInfo.getDisplayName() + " started");
+  }
+   
+  @TestTemplate
+  public void failureDetection(TestInfo testInfo) {
+    Assertions.fail("test should not run");
+  }
+}

--- a/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingTest.java
+++ b/scalecube-fixtures-tck-flow/src/test/java/io/scalecube/test/fixtures/FailingTest.java
@@ -6,16 +6,16 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-//@WithFixture(value = FailingFixtureConstructor.class)
+// @WithFixture(value = FailingFixtureConstructor.class)
 @WithFixture(value = FailingFixtureInSetup.class)
 @ExtendWith(Fixtures.class)
 public class FailingTest {
 
   @BeforeEach
-  void setUp(TestInfo testInfo) {
+  public void setUp(TestInfo testInfo) {
     System.out.println(testInfo.getDisplayName() + " started");
   }
-   
+
   @TestTemplate
   public void failureDetection(TestInfo testInfo) {
     Assertions.fail("test should not run");

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixture.java
@@ -1,6 +1,8 @@
 package io.scalecube.test.fixtures;
 
 import java.lang.reflect.Proxy;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opentest4j.TestAbortedException;
@@ -57,8 +59,12 @@ import org.opentest4j.TestAbortedException;
 public interface Fixture {
 
   /**
-   * Set up the environment access. May throw a {@link TestAbortedException} if something went
-   * wrong.
+   * Set up the environment access. Implementors of this class should throw {@link
+   * TestAbortedException} to indicate that the environment is not set and ready, thus skipping the
+   * test. a nice way to do that is using {@link Assumptions}. If there is a need to fail the entire
+   * test-case - an implementor can do {@link Assertions}. If the setup of the fixture is very
+   * important and must fail the build - an implementor should throw whatever type of unchecked
+   * {@link Exception} thus failing the tests with Error.
    */
   void setUp() throws TestAbortedException;
 
@@ -70,7 +76,7 @@ public interface Fixture {
    * mock, local or remote (using or not using {@link Proxy}).
    *
    * @param clasz the type of the object in the environment. mostly an interface.
-   * @return an access object, nu
+   * @return an access object, can be null.
    */
   <T> T proxyFor(Class<? extends T> clasz);
 

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/FixtureFactory.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/FixtureFactory.java
@@ -1,11 +1,12 @@
 package io.scalecube.test.fixtures;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-/** 
- * An abstract provider for {@link Fixture}.
- * This utility class does not implement {@link Supplier} or {@link Function}.
+/**
+ * An abstract provider for {@link Fixture}. This utility class does not implement {@link Supplier}
+ * or {@link Function}.
  */
 public class FixtureFactory {
 
@@ -19,8 +20,11 @@ public class FixtureFactory {
   public static Fixture getFixture(Class<? extends Fixture> fixtureClass)
       throws FixtureCreationException {
     try {
-      return fixtureClass.newInstance();
-    } catch (InstantiationException | IllegalAccessException cause) {
+      return fixtureClass.getConstructor(new Class[] {}).newInstance();
+    } catch (InvocationTargetException
+        | NoSuchMethodException
+        | InstantiationException
+        | IllegalAccessException cause) {
       throw new FixtureCreationException(cause);
     }
   }

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/FixtureFactory.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/FixtureFactory.java
@@ -1,12 +1,11 @@
 package io.scalecube.test.fixtures;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-/**
- * An abstract provider for {@link Fixture}. This utility class does not implement {@link Supplier}
- * or {@link Function}.
+/** 
+ * An abstract provider for {@link Fixture}.
+ * This utility class does not implement {@link Supplier} or {@link Function}.
  */
 public class FixtureFactory {
 
@@ -20,11 +19,8 @@ public class FixtureFactory {
   public static Fixture getFixture(Class<? extends Fixture> fixtureClass)
       throws FixtureCreationException {
     try {
-      return fixtureClass.getConstructor(new Class[] {}).newInstance();
-    } catch (InvocationTargetException
-        | NoSuchMethodException
-        | InstantiationException
-        | IllegalAccessException cause) {
+      return fixtureClass.newInstance();
+    } catch (InstantiationException | IllegalAccessException cause) {
       throw new FixtureCreationException(cause);
     }
   }

--- a/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
+++ b/scalecube-test-utils/src/main/java/io/scalecube/test/fixtures/Fixtures.java
@@ -126,7 +126,7 @@ public class Fixtures
     return fixture.map(f -> f.proxyFor(paramType)).orElse(null);
   }
 
-  private Function<? super Class<? extends Fixture>, ? extends Fixture> setUp(
+  private static Function<? super Class<? extends Fixture>, ? extends Fixture> setUp(
       Class<? extends Fixture> fixtureClass) {
     return clz -> {
       Fixture f;


### PR DESCRIPTION
The `tearDown()` method will now run when `setUp()` throws `TestAbortedException`. any exceptions thrown by tear down will be suppressed into the `TestAbortedException`.

Closes https://github.com/scalecube/scalecube-test-utils/issues/23